### PR TITLE
Update MFST_xFireFox to pull latest version by default and use HTTPS

### DIFF
--- a/DSCResources/MSFT_xFirefox/MSFT_xFirefox.schema.psm1
+++ b/DSCResources/MSFT_xFirefox/MSFT_xFirefox.schema.psm1
@@ -2,18 +2,18 @@ Configuration MSFT_xFirefox
 {
     param
     (
-        [string]$VersionNumber = "31.0",
+        [string]$VersionNumber = "latest",
         [string]$Language = "en-US",
-    [string]$OS = "win",
+        [string]$OS = "win",
         [string]$MachineBits = "x86",
-    [string]$LocalPath = "$env:SystemDrive\Windows\DtlDownloads\Firefox Setup " + $versionNumber +".exe"
+        [string]$LocalPath = "$env:SystemDrive\Windows\DtlDownloads\Firefox Setup " + $VersionNumber +".exe"
     )
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
     xRemoteFile Downloader
     {
-         Uri = "http://download.mozilla.org/?product=firefox-" + $VersionNumber +"&os="+$OS+"&lang=" + $Language 
-     DestinationPath = $LocalPath
+        Uri = "https://download.mozilla.org/?product=firefox-" + $VersionNumber +"&os="+$OS+"&lang=" + $Language
+        DestinationPath = $LocalPath
     }
      
     Package Installer


### PR DESCRIPTION
This is based on the following documentation
https://download-installer.cdn.mozilla.net/pub/firefox/releases/latest/README.txt
