### PR TITLE
Added dependency on xPSDesiredStateConfiguration and fixing machine bit installer download. Fixes #1 Fixes #3

### DIFF
--- a/DSCResources/MSFT_xFirefox/MSFT_xFirefox.schema.psm1
+++ b/DSCResources/MSFT_xFirefox/MSFT_xFirefox.schema.psm1
@@ -2,27 +2,38 @@ Configuration MSFT_xFirefox
 {
     param
     (
-        [string]$VersionNumber = "latest",
-        [string]$Language = "en-US",
-        [string]$OS = "win",
-        [string]$MachineBits = "x86",
-        [string]$LocalPath = "$env:SystemDrive\Windows\DtlDownloads\Firefox Setup " + $VersionNumber +".exe"
+        [string]
+        $VersionNumber = "latest",
+        [string]
+        $Language = "en-US",
+        [string]
+        $OS = "win",
+        [ValidateSet("x86", "x64")]
+        [string]
+        $MachineBits = "x86",
+        [string]
+        $LocalPath = "$env:SystemDrive\Windows\DtlDownloads\Firefox Setup " + $VersionNumber +".exe"
     )
+    
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
+
+    if ($MachineBits -eq "x64") {
+        $OS += "64"
+    }
 
     xRemoteFile Downloader
     {
-        Uri = "https://download.mozilla.org/?product=firefox-" + $VersionNumber +"&os="+$OS+"&lang=" + $Language
+        Uri = "https://download.mozilla.org/?product=firefox-" + $VersionNumber + "&os=" + $OS + "&lang=" + $Language
         DestinationPath = $LocalPath
     }
      
     Package Installer
     {
-     Ensure = "Present"
-     Path = $LocalPath
-         Name = "Mozilla Firefox " + $VersionNumber + " (" + $MachineBits + " " + $Language +")"
-     ProductId = ''
-         Arguments = "/SilentMode"
-         DependsOn = "[xRemoteFile]Downloader"
+        Ensure = "Present"
+        Path = $LocalPath
+        Name = "Mozilla Firefox " + $VersionNumber + " (" + $MachineBits + " " + $Language +")"
+        ProductId = ''
+        Arguments = "/SilentMode"
+        DependsOn = "[xRemoteFile]Downloader"
     }
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The default is x86.
 
 ### Unreleased
 
+- Added logic to download installer with correct machine bits
+- Added dependency on xPSDesiredStateConfiguration
+
 ### 1.1.0.0
 
 * Updated MFST_xFireFox to pull latest version by default and use HTTPS

--- a/xFirefox.psd1
+++ b/xFirefox.psd1
@@ -48,7 +48,7 @@ Description = 'Firefox Main module'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
+RequiredModules = @( 'xPSDesiredStateConfiguration' )
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()


### PR DESCRIPTION
Added dependency on xPSDesiredStateConfiguration since the resource calls Import-DscResource xPSDesiredStateConfiguration.
This fixes issue #1 and will fix the DSCResources not showing up in the PowerShell Gallery.

I also quickly added the logic to download the correct installer for x64 machines.
This fixes #3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xfirefox/6)
<!-- Reviewable:end -->
